### PR TITLE
Revert "Workaround actions/checkout issue 672 (#4)"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ runs:
   # TODO: Convert to JavaScript runner
   using: "composite"
   steps:
-    - uses: actions/checkout@v2.3.5
+    - uses: actions/checkout@v2
       with:
         fetch-depth: ${{ inputs.checkout-fetch-depth }}
         lfs: ${{ inputs.use-lfs }}


### PR DESCRIPTION
This reverts commit c13669a6e326745286528a9692e3a7e4c3874320.

https://github.com/actions/checkout/issues/672 has been resolved upstream,
workaround no longer required here.